### PR TITLE
Readme TensorFlow 1.6 Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@ Referenced throughout the book.
 ![Book Cover](https://pbs.twimg.com/media/DXQHXOtVoAEO4T_.jpg:large)
 
 </center>
+
+
+## TensorFlow Versions
+
+The TensorFlow library has been evolving rapidly in the last couple years, and some of the code in this repo and the associated book no longer work with the latest versions of TensorFlow. We recommend using TensorFlow 1.6 for working through all exercises in this book. We are looking into creating a full `requirements.txt` file for all needed dependencies and hope to have that available for you soon.
+
+We also welcome any PRs that modify code to work with more recent TensorFlow versions. We are looking into these upgrades on our end as well.


### PR DESCRIPTION
Adds a short description to the README recommending TF 1.6 for examples